### PR TITLE
feat(): set `DotenvConfigLoader` as loader by default

### DIFF
--- a/lib/config.module.ts
+++ b/lib/config.module.ts
@@ -7,7 +7,7 @@ import { DotenvConfigLoader } from './loaders';
 
 export class ConfigModule {
   static forFoot({
-    pattern = '*.ts',
+    pattern = '!(*.d).{ts,js}',
     ...options
   }: O.Optional<IConfigOptions, 'pattern'>): DynamicModule {
     const configProvider: FactoryProvider = {
@@ -30,7 +30,10 @@ export class ConfigModule {
   }
   static forFeature(
     configLoader: IConfigLoader,
-    { pattern = '*.ts', ...options }: O.Optional<IConfigOptions, 'pattern'>,
+    {
+      pattern = '!(*.d).{ts,js}',
+      ...options
+    }: O.Optional<IConfigOptions, 'pattern'>,
   ): DynamicModule {
     const configProvider: FactoryProvider = {
       provide: Config,

--- a/lib/config.module.ts
+++ b/lib/config.module.ts
@@ -8,6 +8,7 @@ import { DotenvConfigLoader } from './loaders';
 export class ConfigModule {
   static forFoot({
     pattern = '!(*.d).{ts,js}',
+    global = false,
     ...options
   }: O.Optional<IConfigOptions, 'pattern'>): DynamicModule {
     const configProvider: FactoryProvider = {
@@ -26,12 +27,14 @@ export class ConfigModule {
       module: ConfigModule,
       exports: [configProvider],
       providers: [configProvider],
+      global,
     };
   }
   static forFeature(
     configLoader: IConfigLoader,
     {
       pattern = '!(*.d).{ts,js}',
+      global = false,
       ...options
     }: O.Optional<IConfigOptions, 'pattern'>,
   ): DynamicModule {
@@ -51,6 +54,7 @@ export class ConfigModule {
       module: ConfigModule,
       exports: [configProvider],
       providers: [configProvider],
+      global,
     };
   }
 }

--- a/lib/config.module.ts
+++ b/lib/config.module.ts
@@ -3,9 +3,32 @@ import { DynamicModule, FactoryProvider } from '@nestjs/common';
 import type { O } from 'ts-toolbelt';
 import { Config } from './config.provider';
 import { IConfigLoader, IConfigOptions } from './interfaces';
+import { DotenvConfigLoader } from './loaders';
 
 export class ConfigModule {
-  static forFoot(
+  static forFoot({
+    pattern = '*.ts',
+    ...options
+  }: O.Optional<IConfigOptions, 'pattern'>): DynamicModule {
+    const configProvider: FactoryProvider = {
+      provide: Config,
+      useFactory: async () =>
+        await defer(async () => {
+          const config = new Config(new DotenvConfigLoader(), {
+            pattern,
+            ...options,
+          });
+          await config.load();
+          return config;
+        }).toPromise(),
+    };
+    return {
+      module: ConfigModule,
+      exports: [configProvider],
+      providers: [configProvider],
+    };
+  }
+  static forFeature(
     configLoader: IConfigLoader,
     { pattern = '*.ts', ...options }: O.Optional<IConfigOptions, 'pattern'>,
   ): DynamicModule {

--- a/lib/interfaces/config.interface.ts
+++ b/lib/interfaces/config.interface.ts
@@ -7,4 +7,5 @@ export interface IConfigBootSpec {
 export interface IConfigOptions {
   path: string;
   pattern: string;
+  global?: boolean;
 }

--- a/test/config-module.spec.ts
+++ b/test/config-module.spec.ts
@@ -2,7 +2,12 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import { Test } from '@nestjs/testing';
-import { Config, ConfigModule, IConfigLoader } from '../lib';
+import {
+  Config,
+  ConfigModule,
+  DotenvConfigLoader,
+  IConfigLoader,
+} from '../lib';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -17,11 +22,20 @@ describe('ConfigModule', () => {
   afterEach(() => {
     sinon.restore();
   });
-  it('should provide', async () => {
+  it('should provide `DotenvConfigLoader` by default', async () => {
     const testModule = await Test.createTestingModule({
-      imports: [ConfigModule.forFoot(new TestLoader(), { path: 'test' })],
+      imports: [ConfigModule.forFoot({ path: 'test' })],
     }).compile();
     const config = testModule.get(Config);
     expect(config).instanceOf(Config);
+    expect(config).property('_loader').instanceOf(DotenvConfigLoader);
+  });
+  it('should provide custom provide', async () => {
+    const testModule = await Test.createTestingModule({
+      imports: [ConfigModule.forFeature(new TestLoader(), { path: 'test' })],
+    }).compile();
+    const config = testModule.get(Config);
+    expect(config).instanceOf(Config);
+    expect(config).property('_loader').instanceOf(TestLoader);
   });
 });

--- a/test/config-module.spec.ts
+++ b/test/config-module.spec.ts
@@ -38,4 +38,12 @@ describe('ConfigModule', () => {
     expect(config).instanceOf(Config);
     expect(config).property('_loader').instanceOf(TestLoader);
   });
+  it('module by default should be scoped', async () => {
+    const dynamicModule = ConfigModule.forFoot({ path: 'test' });
+    expect(dynamicModule).property('global').is.false;
+  });
+  it('module can be set as a global', () => {
+    const dynamicModule = ConfigModule.forFoot({ path: 'test', global: true });
+    expect(dynamicModule).property('global').is.true;
+  });
 });


### PR DESCRIPTION
Closes #6

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6 


## What is the new behavior?
Now function `forRoot()` by default provide `DotenvConfigLoader` and providing custom loader moved to `forFeature()` function

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
`forRoot()` function no longer accept custom loader
